### PR TITLE
fix: CI frontend build TS6133 errors

### DIFF
--- a/src/frontend/tsconfig.json
+++ b/src/frontend/tsconfig.json
@@ -17,5 +17,6 @@
     "noFallthroughCasesInSwitch": true
   },
   "include": ["src"],
+  "exclude": ["src/**/__tests__/**", "src/**/*.test.ts", "src/**/*.spec.ts"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }


### PR DESCRIPTION
Fixes tsc build failures caused by unused variables in test files being picked up by the build TypeScript compilation. Excluded test files from build tsconfig.