### PR TITLE
fix: opentype.js CJS/ESM interop in Vitest

### DIFF
--- a/src/frontend/src/font/__tests__/FontLoader.test.ts
+++ b/src/frontend/src/font/__tests__/FontLoader.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { describe, it, expect, vi } from 'vitest';
 import { FontLoader } from '../FontLoader';
 

--- a/src/frontend/src/test-setup.ts
+++ b/src/frontend/src/test-setup.ts
@@ -1,0 +1,36 @@
+// Define browser APIs not implemented by jsdom
+if (typeof URL.createObjectURL === 'undefined') {
+  Object.defineProperty(URL, 'createObjectURL', { writable: true, configurable: true, value: () => '' });
+}
+if (typeof URL.revokeObjectURL === 'undefined') {
+  Object.defineProperty(URL, 'revokeObjectURL', { writable: true, configurable: true, value: () => {} });
+}
+
+// Provide a minimal canvas 2D context mock for jsdom (no native canvas bindings).
+// Only applied when running in a browser-like environment (jsdom/happy-dom).
+if (typeof HTMLCanvasElement !== 'undefined') {
+  const mock2dContext = {
+    clearRect: () => {},
+    fillRect: () => {},
+    fill: () => {},
+    set fillStyle(_: string) {},
+    get fillStyle() { return '#000'; },
+    getImageData: (_x: number, _y: number, w: number, h: number) => ({
+      data: new Uint8ClampedArray(w * h * 4).fill(255), // all-white pixels
+      width: w,
+      height: h,
+    }),
+  };
+
+  HTMLCanvasElement.prototype.getContext = function (contextId: string) {
+    if (contextId === '2d') return mock2dContext as unknown as CanvasRenderingContext2D;
+    return null;
+  } as typeof HTMLCanvasElement.prototype.getContext;
+}
+
+// Path2D is not available in jsdom; provide a no-op stub.
+if (typeof (globalThis as any).Path2D === 'undefined') {
+  (globalThis as any).Path2D = class Path2D {
+    constructor(_?: string) {}
+  };
+}

--- a/src/frontend/vitest.config.ts
+++ b/src/frontend/vitest.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+import path from 'path';
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      'opentype.js': path.resolve(__dirname, 'node_modules/opentype.js/dist/opentype.module.js'),
+    },
+  },
+  test: {
+    setupFiles: ['./src/test-setup.ts'],
+    deps: {
+      optimizer: {
+        web: {
+          include: ['opentype.js'],
+        },
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Problem

src/fontPipeline.test.ts and src/font/__tests__/FontLoader.test.ts crashed at suite load time with:

\\\
TypeError: Cannot assign to read only property 'load' of object '[object Object]'
  ❯ node_modules/opentype.js/dist/opentype.js:14470:15
\\\

0 tests ran in either suite.

## Root Cause

opentype.js ships both a CJS/UMD bundle (dist/opentype.js, used by Node require) and an ESM build (dist/opentype.module.js). Vitest was resolving to the CJS bundle, whose factory function does xports.load = load — but in Vitest's ESM strict mode the xports object is sealed, making that assignment throw.

## Fix

**src/frontend/vitest.config.ts** (new file): adds a esolve.alias pointing opentype.js → dist/opentype.module.js, ensuring Vitest always loads the native ESM build.

**src/frontend/src/test-setup.ts** (new file): stubs browser APIs absent from jsdom (URL.createObjectURL/revokeObjectURL, canvas getContext('2d'), Path2D) so browser-environment tests run without native bindings. Guards are in place so the stubs only activate in jsdom/happy-dom environments.

**src/frontend/src/font/__tests__/FontLoader.test.ts**: added // @vitest-environment jsdom directive (was missing; xtractStyleGlyphs calls document.createElement).

## Result

All 41 tests across all 5 suites pass (was: 20 passing, 2 suites crashing at load).