### PR TITLE
fix: resolve ModelPath to repo-root models dir in development (#35)

### DIFF
--- a/src/backend/CyrillicFontGen.Api.Tests/ApiIntegrationTests.cs
+++ b/src/backend/CyrillicFontGen.Api.Tests/ApiIntegrationTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
 
 namespace CyrillicFontGen.Api.Tests;
 
@@ -8,10 +9,26 @@ public class ApiIntegrationTests : IClassFixture<WebApplicationFactory<Program>>
     private readonly WebApplicationFactory<Program> _factory;
     private readonly HttpClient _client;
 
+    // Factory that overrides ModelPath to a non-existent directory, simulating a missing model.
+    private readonly WebApplicationFactory<Program> _noModelFactory;
+    private readonly HttpClient _noModelClient;
+
     public ApiIntegrationTests(WebApplicationFactory<Program> factory)
     {
         _factory = factory;
         _client = factory.CreateClient();
+
+        _noModelFactory = factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureAppConfiguration((_, config) =>
+            {
+                config.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["ModelPath"] = "/nonexistent/path/that/does/not/exist"
+                });
+            });
+        });
+        _noModelClient = _noModelFactory.CreateClient();
     }
 
     [Fact]
@@ -39,7 +56,7 @@ public class ApiIntegrationTests : IClassFixture<WebApplicationFactory<Program>>
     [Fact]
     public async Task VersionedModelEndpoint_WhenModelNotExists_Returns404()
     {
-        var response = await _client.GetAsync("/api/model/v1/generator.onnx");
+        var response = await _noModelClient.GetAsync("/api/model/v1/generator.onnx");
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
 
@@ -47,7 +64,7 @@ public class ApiIntegrationTests : IClassFixture<WebApplicationFactory<Program>>
     public async Task ModelEndpoint_WhenModelNotExists_Returns404()
     {
         // Act
-        var response = await _client.GetAsync("/api/model");
+        var response = await _noModelClient.GetAsync("/api/model");
 
         // Assert
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);

--- a/src/backend/CyrillicFontGen.Api/appsettings.Development.json
+++ b/src/backend/CyrillicFontGen.Api/appsettings.Development.json
@@ -4,5 +4,6 @@
       "Default": "Debug",
       "Microsoft.AspNetCore": "Information"
     }
-  }
+  },
+  "ModelPath": "../../../models"
 }

--- a/src/backend/README.md
+++ b/src/backend/README.md
@@ -15,7 +15,14 @@ dotnet run --project CyrillicFontGen.Api
 | Artifact | Location |
 |---|---|
 | React build output | `CyrillicFontGen.Api/wwwroot/` |
-| Trained ONNX model | `CyrillicFontGen.Api/models/v1/generator.onnx` |
+| Trained ONNX model | `models/v1/generator.onnx` (repo root, **not** inside the API project) |
+
+> **Development:** `appsettings.Development.json` overrides `ModelPath` to `"../../../models"`, resolving
+> `src/backend/CyrillicFontGen.Api/` → 3 levels up → repo root `models/`. No extra setup needed.
+>
+> **Production (published):** When publishing with `dotnet publish`, place `models/v1/generator.onnx`
+> **alongside the published binary** (i.e., in the same directory as `CyrillicFontGen.Api.dll`).
+> The default `ModelPath: "models"` in `appsettings.json` will then resolve correctly from `ContentRootPath`.
 
 ## API surface
 


### PR DESCRIPTION
## Problem

appsettings.json sets ModelPath: "models" which resolves relative to ContentRootPath (src/backend/CyrillicFontGen.Api/ in dev). The actual model lives at the repo root models/v1/generator.onnx, so both GET /api/model and GET /api/model/v1/generator.onnx returned 404.

## Fix

Add ModelPath override in appsettings.Development.json:
  "ModelPath": "../../../models"

Path.GetFullPath(Path.Combine(ContentRootPath, "../../../models")) walks up 3 levels to the repo root, resolving to the correct models/ directory.

## Also changed

- src/backend/README.md - clarifies correct model placement for dev (repo root) and production (alongside published binary).
- ApiIntegrationTests.cs - the two 'model not exists' 404 tests now use a custom WebApplicationFactory injecting a non-existent path, rather than relying on an incorrect path as accidental side-effect. All 25 tests pass.

Fixes #35