### PR TITLE
fix: restore style conditioning — copy ONNX output buffer to prevent SharedArrayBuffer aliasing

### DIFF
--- a/src/frontend/src/inference/ModelLoader.ts
+++ b/src/frontend/src/inference/ModelLoader.ts
@@ -52,7 +52,12 @@ export class ModelLoader {
         } else if (msg.type === 'result') {
           const pending = this.pendingRequests.get(msg.requestId);
           if (pending) {
-            pending.resolve(msg.output);
+            // Defensive copy: ORT's WASM backend may return a Float32Array that
+            // views SharedArrayBuffer (WASM memory). postMessage does not clone
+            // SAB — the received Float32Array would alias the same WASM memory
+            // and would be overwritten by the next inference.  Copying here
+            // guarantees an independent buffer regardless of SAB availability.
+            pending.resolve(new Float32Array(msg.output));
             this.pendingRequests.delete(msg.requestId);
           }
         } else if (msg.type === 'error') {

--- a/src/frontend/src/inference/__tests__/integration.test.ts
+++ b/src/frontend/src/inference/__tests__/integration.test.ts
@@ -183,4 +183,37 @@ describe('Inference Pipeline Integration', () => {
 
     expect(revoke).toHaveBeenCalledWith('blob:test-url');
   });
+
+  it('each infer result is an independent copy — not a shared-buffer alias (regression: #39)', async () => {
+    // Simulate the ORT WASM SharedArrayBuffer reuse scenario:
+    // The "worker" sends the SAME Float32Array reference every call and
+    // overwrites its values before each response.  Without a defensive copy in
+    // ModelLoader.resolve (or in the worker), all stored results would reflect
+    // only the last inference, making every assembled glyph identical.
+    const sharedOutput = new Float32Array(128 * 128);
+    let seq = 0;
+
+    mockWorker.postMessage = vi.fn((msg: any) => {
+      if (msg.type === 'infer') {
+        Promise.resolve().then(() => {
+          sharedOutput.fill(++seq); // overwrite buffer with incrementing sentinel
+          mockWorker.onmessage?.({ data: { type: 'result', output: sharedOutput, requestId: msg.requestId } });
+        });
+      }
+    });
+
+    await loadModel();
+
+    const styleGlyphs = new Float32Array(10 * 128 * 128).fill(0.5);
+    const r1 = await modelLoader.infer(styleGlyphs, 0);
+    const r2 = await modelLoader.infer(styleGlyphs, 1);
+    const r3 = await modelLoader.infer(styleGlyphs, 2);
+
+    // Each result must snapshot the value it had at the moment of inference.
+    // Without defensive copy: r1[0] === r2[0] === r3[0] === 3 (all overwritten).
+    // With copy in ModelLoader.resolve: r1[0] === 1, r2[0] === 2, r3[0] === 3.
+    expect(r1[0]).toBe(1);
+    expect(r2[0]).toBe(2);
+    expect(r3[0]).toBe(3);
+  });
 });

--- a/src/frontend/src/inference/worker/inferenceWorker.ts
+++ b/src/frontend/src/inference/worker/inferenceWorker.ts
@@ -105,6 +105,14 @@ async function runInference(
   const outputTensor = results['generated_glyph'] ?? results['output'] ?? Object.values(results)[0];
   const outputData = outputTensor.data as Float32Array;
 
-  // Return raw float32 data [1, 1, 128, 128] → flatten to [16384]
-  return outputData;
+  // ⚠️ Critical: copy output before returning.
+  //
+  // ORT's WASM backend returns a Float32Array that is a *view* into
+  // WebAssembly.Memory. On cross-origin-isolated pages SharedArrayBuffer is
+  // used for WASM memory; postMessage does NOT clone SAB views — the receiver
+  // gets an alias into the same physical memory. ORT reuses its output buffer
+  // between session.run() calls, so without an explicit copy every result stored
+  // in App.tsx rawGlyphs would reflect only the *last* inference, making all 66
+  // assembled glyphs identical regardless of char_index or style input.
+  return new Float32Array(outputData);
 }


### PR DESCRIPTION
Fixes #39

## Root cause

ORT's WASM backend returns \outputTensor.data\ as a \Float32Array\ that is a **view into \WebAssembly.Memory\**. On cross-origin-isolated pages (required for multi-threaded ONNX Runtime Web), WASM memory is a \SharedArrayBuffer\. \postMessage\ does NOT structured-clone \SharedArrayBuffer\ views — the main thread receives an alias into the exact same physical memory.

ORT reuses its single output buffer between \session.run()\ calls. This means every entry stored in \App.tsx rawGlyphs\ ends up pointing to the same memory region, which is overwritten with each new inference. After all 66 inferences complete, every \awGlyphs\ entry reflects only the **last** inference result — the assembled \.otf\ font contains 66 identical glyphs, completely ignoring font style and character identity.

## Fix

Two defensive copies added:
1. **\inferenceWorker.ts\** — \eturn new Float32Array(outputData)\ before returning from \unInference()\. Copies from WASM/SAB heap into a regular \ArrayBuffer\ before \postMessage\. This is the primary fix.
2. **\ModelLoader.ts\** — \pending.resolve(new Float32Array(msg.output))\ when receiving the result. Belt-and-suspenders copy for environments where SAB may pass through unmolested.

## Verification

- 1 regression test added to \integration.test.ts\: simulates the shared-buffer alias scenario (same \Float32Array\ reference returned per call, values overwritten before each response) and asserts each result independently snapshots its value at inference time.
- All **114 tests pass** (113 baseline + 1 new).