### PR TITLE
fix(inference): copy SAB-backed Float32Array in OnnxInference.ts

### DIFF
--- a/src/frontend/src/inference/OnnxInference.ts
+++ b/src/frontend/src/inference/OnnxInference.ts
@@ -79,8 +79,13 @@ export class OnnxInference {
       throw new Error('Model not loaded. Call loadModel() first.');
     }
 
-    // style_glyphs: [1, 10, 1, 128, 128] — batch dimension required
-    const styleTensor = new ort.Tensor('float32', styleGlyphs, [1, 10, 1, 128, 128]);
+    // style_glyphs: [1, 10, 1, 128, 128] — batch dimension required.
+    // Guard: if styleGlyphs is backed by a SharedArrayBuffer (SAB), copy it to a plain
+    // ArrayBuffer first — ORT's WASM backend cannot accept SAB-backed views directly.
+    const safeStyleGlyphs = styleGlyphs.buffer instanceof SharedArrayBuffer
+      ? new Float32Array(styleGlyphs.buffer.slice(styleGlyphs.byteOffset, styleGlyphs.byteOffset + styleGlyphs.byteLength))
+      : styleGlyphs;
+    const styleTensor = new ort.Tensor('float32', safeStyleGlyphs, [1, 10, 1, 128, 128]);
     const indexTensor = new ort.Tensor('int64', BigInt64Array.from([BigInt(charIndex)]), [1]);
 
     const results = await this.session.run({


### PR DESCRIPTION
Applies the same SharedArrayBuffer aliasing fix from PR #40 to the test-only OnnxInference.ts path.

## What changed

In OnnxInference.generateGlyph(), the styleGlyphs parameter is now checked for SharedArrayBuffer backing before being passed to ort.Tensor. If SAB-backed, uffer.slice() is used to copy to a plain ArrayBuffer first — matching the copy pattern established in inferenceWorker.ts.

## Why

ORT's WASM backend cannot safely consume SAB-backed typed array views. Without the copy, the tensor would alias live SAB memory, which is both a correctness risk (data may change mid-inference) and a security concern (Spectre-class side channels).

Closes #41